### PR TITLE
Add scheduled weather notifier workflow

### DIFF
--- a/.github/workflows/weather.yml
+++ b/.github/workflows/weather.yml
@@ -1,0 +1,15 @@
+name: Weather Notifier
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+jobs:
+  send_weather:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: pip install requests
+      - name: Run notifier
+        run: python weather_notifier.py


### PR DESCRIPTION
## Summary
- add CI workflow to run weather notifier script daily

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846f9faf994832e852bd6c8ec3292fd