### PR TITLE
Add daily weather notifier workflow

### DIFF
--- a/.github/workflows/daily-weather-notifier.yml
+++ b/.github/workflows/daily-weather-notifier.yml
@@ -1,0 +1,30 @@
+name: Daily Weather Notifier
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Runs daily at 8:00 AM UTC
+  workflow_dispatch:
+
+jobs:
+  run-weather:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: pip install requests
+
+    - name: Run script
+      env:
+        BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+        CHAT_ID: ${{ secrets.CHAT_ID }}
+        WEATHER_API_KEY: ${{ secrets.WEATHER_API_KEY }}
+      run: |
+        python weather_notifier.py


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run the weather notifier script daily

## Testing
- `python -m py_compile weather_notifier.py`


------
https://chatgpt.com/codex/tasks/task_e_6846fb4129a0832eb1d267480ffdaae0