### PR TITLE
Fix missing os import

### DIFF
--- a/weather_notifier.py
+++ b/weather_notifier.py
@@ -1,3 +1,4 @@
+import os
 import requests
 
 # === CONFIG ===


### PR DESCRIPTION
## Summary
- import os so environment variables work

## Testing
- `python -m py_compile weather_notifier.py`

------
https://chatgpt.com/codex/tasks/task_e_6846ff4b6e58832eaf3c97bfb511cef8